### PR TITLE
fix: pawns now have short memory for boredom

### DIFF
--- a/FreeWill_MapComponent.cs
+++ b/FreeWill_MapComponent.cs
@@ -13,6 +13,7 @@ namespace FreeWill
         private static Action[] mapCompnentsCheckActions;
 
         private Dictionary<Pawn, Dictionary<WorkTypeDef, Priority>> priorities;
+        private Dictionary<Pawn, int> lastBored;
         private readonly FieldInfo activeAlertsField;
         private FreeWill_WorldComponent worldComp;
 
@@ -59,7 +60,7 @@ namespace FreeWill
         public bool AlertLowFood { get { return alertLowFood; } }
         private bool alertLowFood;
 
-        private int mapTickCounter = 0;
+        private int actionCounter = 0;
 
         public FreeWill_MapComponent(Map map) : base(map)
         {
@@ -85,12 +86,12 @@ namespace FreeWill
 
             try
             {
-                getMapComponentTickAction(this.mapTickCounter)();
-                this.mapTickCounter++;
+                getMapComponentTickAction(this.actionCounter)();
+                this.actionCounter++;
             }
             catch (System.Exception e)
             {
-                Log.ErrorOnce($"Free Will: could not perform tick action: mapTickCounter = {this.mapTickCounter}: {e}", 14147584);
+                Log.ErrorOnce($"Free Will: could not perform tick action: mapTickCounter = {this.actionCounter}: {e}", 14147584);
             }
         }
 
@@ -107,7 +108,7 @@ namespace FreeWill
                 int pawnCount = this.map.mapPawns.FreeColonistsSpawnedCount;
                 if (i >= worktypeCount * pawnCount)
                 {
-                    this.mapTickCounter = 0;
+                    this.actionCounter = 0;
                     return getMapComponentTickAction(0);
                 }
                 int pawnIndex = i / worktypeCount;
@@ -117,9 +118,23 @@ namespace FreeWill
             // show stack trace
             catch (System.Exception e)
             {
-                Log.ErrorOnce($"Free Will: could not get map component tick action: mapTickCounter = {this.mapTickCounter}: {e}", 14847584);
+                Log.ErrorOnce($"Free Will: could not get map component tick action: mapTickCounter = {this.actionCounter}: {e}", 14847584);
                 return () => { };
             }
+        }
+
+        public void UpdateLastBored(Pawn pawn)
+        {
+            this.lastBored[pawn] = Find.TickManager.TicksGame;
+        }
+
+        public int GetLastBored(Pawn pawn)
+        {
+            if (this.lastBored.ContainsKey(pawn))
+            {
+                return this.lastBored[pawn];
+            }
+            return 0;
         }
 
         public Dictionary<WorkTypeDef, Priority> GetPriorities(Pawn pawn)

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -69,6 +69,7 @@
   <FreeWillPriorityHealth>current health</FreeWillPriorityHealth>
   <FreeWillPriorityBuildingImmunity>building immunity</FreeWillPriorityBuildingImmunity>
   <FreeWillPriorityBored>bored</FreeWillPriorityBored>
+  <FreeWillPriorityWasBored>was recently bored</FreeWillPriorityWasBored>
   <FreeWillPriorityRefueling>refueling required</FreeWillPriorityRefueling>
   <FreeWillPriorityFilthyCookingArea>dirty cooking area</FreeWillPriorityFilthyCookingArea>
   <FreeWillPriorityBestAtDoing>best at doing</FreeWillPriorityBestAtDoing>

--- a/Priority.cs
+++ b/Priority.cs
@@ -817,7 +817,15 @@ namespace FreeWill
 
         private Priority considerBored()
         {
-            return this.alwaysDoIf(pawn.mindState.IsIdle, "FreeWillPriorityBored".TranslateSimple());
+            const int boredomMemory = 2500; // 1 hour in game
+            if (this.pawn.mindState.IsIdle)
+            {
+                (this.mapComp as FreeWill_MapComponent)?.UpdateLastBored(this.pawn);
+                return this.alwaysDoIf(pawn.mindState.IsIdle, "FreeWillPriorityBored".TranslateSimple());
+            }
+            var lastBored = (this.mapComp as FreeWill_MapComponent)?.GetLastBored(this.pawn);
+            var wasBored = lastBored != 0 && Find.TickManager.TicksGame - lastBored < boredomMemory;
+            return this.alwaysDoIf(wasBored, "FreeWillPriorityWasBored".TranslateSimple());
         }
 
         private Priority considerHasHuntingWeapon()


### PR DESCRIPTION
In earlier version, pawns would have all work types activated when they were bored. When they started doing an activity, this work types would be disabled again.

This led to an issue where pawns would try to start researching and then immediately stop.

This change gives pawns a short internal memory (not an in-game memory) of being bored and they will keep all work types turned on for 1 in-game hour.