### PR TITLE
Option to space out calculations

### DIFF
--- a/FreeWill_MapComponent.cs
+++ b/FreeWill_MapComponent.cs
@@ -84,15 +84,18 @@ namespace FreeWill
                 checkActiveAlerts,
             };
             worldComp = Find.World.GetComponent<FreeWill_WorldComponent>();
+            if (Find.TickManager.TicksGame % worldComp.settings.SkipCalcTicks == 0)
+            {
 
-            try
-            {
-                getMapComponentTickAction()();
-                this.actionCounter++;
-            }
-            catch (System.Exception e)
-            {
-                Log.ErrorOnce($"Free Will: could not perform tick action: mapTickCounter = {this.actionCounter}: {e}", 14147584);
+                try
+                {
+                    getMapComponentTickAction()();
+                    this.actionCounter++;
+                }
+                catch (System.Exception e)
+                {
+                    Log.ErrorOnce($"Free Will: could not perform tick action: mapTickCounter = {this.actionCounter}: {e}", 14147584);
+                }
             }
         }
 

--- a/FreeWill_ModSettings.cs
+++ b/FreeWill_ModSettings.cs
@@ -8,7 +8,7 @@ namespace FreeWill
     public class FreeWill_ModSettings : ModSettings
     {
         // mod default settings
-        const int SkipCalcTicksDefault = 20;
+        const int SkipCalcTicksDefault = 4;
         const bool ConsiderBrawlersNotHuntingDefault = true;
         const bool ConsiderHasHuntingWeaponDefault = true;
         const float ConsiderMovementSpeedDefault = 1.0f;

--- a/FreeWill_ModSettings.cs
+++ b/FreeWill_ModSettings.cs
@@ -8,6 +8,7 @@ namespace FreeWill
     public class FreeWill_ModSettings : ModSettings
     {
         // mod default settings
+        const int SkipCalcTicksDefault = 20;
         const bool ConsiderBrawlersNotHuntingDefault = true;
         const bool ConsiderHasHuntingWeaponDefault = true;
         const float ConsiderMovementSpeedDefault = 1.0f;
@@ -21,6 +22,7 @@ namespace FreeWill
         const float ConsiderPlantsBlightedDefault = 1.0f;
         const float ConsiderGauranlenPruningDefault = 1.0f;
 
+        public int SkipCalcTicks = SkipCalcTicksDefault;
         public bool ConsiderBrawlersNotHunting = ConsiderBrawlersNotHuntingDefault;
         public bool ConsiderHasHuntingWeapon = ConsiderHasHuntingWeaponDefault;
         public float ConsiderMovementSpeed = ConsiderMovementSpeedDefault;
@@ -70,6 +72,17 @@ namespace FreeWill
             view.height = 9999.0f;
             ls.Begin(new Rect(10, 10, view.width - 40, view.height - 10));
             ls.Gap(30.0f);
+
+            s1 = "FreeWillSkipTicks".TranslateSimple();
+            s2 = String.Format("{0} ticks pause", SkipCalcTicks);
+            s3 = "FreeWillSkipTicksLong".TranslateSimple();
+            ls.LabelDouble(s1, s2, tip: s3);
+            SkipCalcTicks = Mathf.RoundToInt(ls.Slider(SkipCalcTicks, 1.0f, 100.0f));
+            if (ls.ButtonText("FreeWillDefaultSliderButtonLabel".TranslateSimple()))
+            {
+                SkipCalcTicks = SkipCalcTicksDefault;
+            }
+            ls.GapLine(30.0f);
 
             s1 = "FreeWillConsiderMovementSpeed".TranslateSimple();
             s2 = String.Format("{0}x", ConsiderMovementSpeed);
@@ -218,6 +231,7 @@ namespace FreeWill
 
         public override void ExposeData()
         {
+            Scribe_Values.Look(ref SkipCalcTicks, "freeWillSkipCalcTicks", SkipCalcTicksDefault, true);
             Scribe_Values.Look(ref ConsiderMovementSpeed, "freeWillConsiderMovementSpeed", ConsiderMovementSpeedDefault, true);
             Scribe_Values.Look(ref ConsiderPassions, "freeWillConsiderPassions", ConsiderPassionsDefault, true);
             Scribe_Values.Look(ref ConsiderBeauty, "freeWillConsiderBeauty", ConsiderBeautyDefault, true);

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -8,7 +8,10 @@
   <FreeWillDefaultSliderButtonLabel>Default</FreeWillDefaultSliderButtonLabel>
   <FreeWillResetGlobalSlidersButtonLabel>Reset global sliders</FreeWillResetGlobalSlidersButtonLabel>
   <FreeWillResetGlobalSlidersLabel>Reset all global overrides to zero</FreeWillResetGlobalSlidersLabel>
-
+  <FreeWillSkipTicks>Skip ticks</FreeWillSkipTicks>
+  <FreeWillSkipTicksLong>Only run priority calculations every x ticks to save resources.</FreeWillSkipTicksLong>
+  
+  
   <!-- Mod ITab -->
   <FreeWillITab>Free will</FreeWillITab>
   <FreeWillITabCheckbox>Free will</FreeWillITabCheckbox>


### PR DESCRIPTION
I noticed on a new map with only one pawn that enabling or disabling free will on the pawn was the difference between 300 ticks per second and 600 ticks per second while the pawn slept.
Analyzing with Dubs Performance Analyzer further I saw that the FreeWill_MapComponent took 90% of time spent in "Map Component Tick" and 99% of that was "System:Action.Invoke". So I looked into your code and decided that it won't need to spend time to calculate and set priorities every tick and made it so it only execute the tick action every X ticks.

This simple "fix" works fine for me as I'm playing it right now.

Basically makes it so it doesn't calculate every tick but skips some between calculations Integrated into the options menu
defaults to 20 ticks pause