### PR TITLE
feat: suppress calculations while sleeping

### DIFF
--- a/FreeWill_MapComponent.cs
+++ b/FreeWill_MapComponent.cs
@@ -160,6 +160,10 @@ namespace FreeWill
                 Log.ErrorOnce($"Free Will: pawn is null: mapTickCounter = {this.actionCounter}", 584624);
                 return;
             }
+            if (!pawn.Awake() || pawn.Downed || pawn.Dead)
+            {
+                return;
+            }
             if (pawn.IsSlaveOfColony)
             {
                 if (worldComp.HasFreeWill(pawn))


### PR DESCRIPTION
Priority updates will not occur on pawns that are asleep or otherwise incapacitated.