### PR TITLE
Add customizable RimWorld path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <RimWorldDir Condition="'$(RIMWORLD_DIR)' != ''">$(RIMWORLD_DIR)</RimWorldDir>
+    <RimWorldDir Condition="'$(RIMWORLD_DIR)' == ''">C:\Program Files (x86)\Steam\steamapps\common\RimWorld</RimWorldDir>
+  </PropertyGroup>
+</Project>

--- a/FreeWill.csproj
+++ b/FreeWill.csproj
@@ -4,11 +4,8 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 
   <PropertyGroup>
-    <SteamBasePath>C:\Program Files (x86)\Steam</SteamBasePath>
-
-    <RimWorldBasePath>$(SteamBasePath)\steamapps\common\RimWorld</RimWorldBasePath>
-    <RimWorldManaged>$(RimWorldBasePath)\RimWorldWin64_Data\Managed</RimWorldManaged>
-    <ModOutputPath>$(RimWorldBasePath)\Mods\FreeWill</ModOutputPath>
+    <RimWorldManaged>$(RimWorldDir)\RimWorldWin64_Data\Managed</RimWorldManaged>
+    <ModOutputPath>$(RimWorldDir)\Mods\FreeWill</ModOutputPath>
 
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AssemblyName>FreeWill</AssemblyName>
@@ -45,7 +42,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>$(SteamBasePath)\steamapps\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
+      <HintPath>$(RimWorldDir)\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 Colonists have free will! Adds a precept that influences how willing colonists
 are to do what they're told.
+
+The project assumes RimWorld is installed in
+`C:\Program Files (x86)\Steam\steamapps\common\RimWorld`. Set the
+`RIMWORLD_DIR` environment variable to point to a different installation
+directory before building.


### PR DESCRIPTION
## Summary
- enable overriding the RimWorld install directory with the `RIMWORLD_DIR` env var via new `Directory.Build.props`
- update `FreeWill.csproj` to use the `RimWorldDir` property
- document the new variable in the README

## Testing
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e80495a9083238be787322c820b1d