### PR TITLE
Add FreeWill.Core project

### DIFF
--- a/Core/FreeWill.Core.csproj
+++ b/Core/FreeWill.Core.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <AssemblyName>FreeWill.Core</AssemblyName>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
## Summary
- introduce `FreeWill.Core` under a new `Core` directory
- target .NET Framework 4.7.2 with no game dependencies

## Testing
- `dotnet build Core/FreeWill.Core.csproj -v minimal` *(fails: reference assemblies for .NETFramework v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513e2c78d48323a3760abd54509eb0