### PR TITLE
Add interfaces for core game abstractions

### DIFF
--- a/Core/FreeWill.Core.csproj
+++ b/Core/FreeWill.Core.csproj
@@ -6,5 +6,11 @@
     <AssemblyName>FreeWill.Core</AssemblyName>
     <OutputType>Library</OutputType>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Interfaces\IPawn.cs" />
+    <Compile Include="Interfaces\IMap.cs" />
+    <Compile Include="Interfaces\IWorldComponent.cs" />
+    <Compile Include="Interfaces\IWorkTypeDef.cs" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Core/Interfaces/IMap.cs
+++ b/Core/Interfaces/IMap.cs
@@ -1,0 +1,16 @@
+using RimWorld;
+using Verse;
+
+namespace FreeWill.Core.Interfaces
+{
+    // Placeholder for Verse.Map
+    public interface IMap
+    {
+        MapPawns mapPawns { get; }
+        AreaManager areaManager { get; }
+        ListerThings listerThings { get; }
+        DesignationManager designationManager { get; }
+
+        T GetComponent<T>() where T : MapComponent;
+    }
+}

--- a/Core/Interfaces/IPawn.cs
+++ b/Core/Interfaces/IPawn.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace FreeWill.Core.Interfaces
+{
+    // Placeholder for Verse.Pawn
+    public interface IPawn
+    {
+        IMap Map { get; }
+        IntVec3 Position { get; }
+
+        string GetUniqueLoadID();
+        string NameShortColored { get; }
+        Name Name { get; }
+
+        bool Downed { get; }
+        bool Dead { get; }
+        bool Awake();
+        bool IsColonistPlayerControlled { get; }
+        bool IsSlaveOfColony { get; }
+        bool IsColonyMechPlayerControlled { get; }
+        bool IsCharging();
+
+        Pawn_WorkSettings workSettings { get; }
+        PlayerSettings playerSettings { get; }
+        Pawn_MindState mindState { get; }
+        Pawn_StoryTracker story { get; }
+        Pawn_HealthTracker health { get; }
+        Pawn_NeedsTracker needs { get; }
+        Pawn_SkillTracker skills { get; }
+        Pawn_JobTracker jobs { get; }
+        Pawn_CarryTracker carryTracker { get; }
+        Pawn_EquipmentTracker equipment { get; }
+        Pawn_ConnectionsTracker connections { get; }
+        RaceProperties RaceProps { get; }
+
+        Room GetRoom();
+        bool WorkTypeIsDisabled(WorkTypeDef workType);
+        bool CanReserve(Thing t, int stackCount = 1, int max = -1, ReservationLayerDef layer = null, bool ignoreOtherReservations = false);
+        Building_Bed CurrentBed();
+    }
+}

--- a/Core/Interfaces/IWorkTypeDef.cs
+++ b/Core/Interfaces/IWorkTypeDef.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using RimWorld;
+
+namespace FreeWill.Core.Interfaces
+{
+    // Placeholder for RimWorld.WorkTypeDef
+    public interface IWorkTypeDef
+    {
+        string defName { get; }
+        string pawnLabel { get; }
+        string description { get; }
+        int index { get; }
+        List<SkillDef> relevantSkills { get; }
+        IEnumerable<IWorkTypeDef> requiredNonDisabledWorkTypes { get; }
+        IEnumerable<IWorkTypeDef> requiredAnyNonDisabledWorkType { get; }
+    }
+}

--- a/Core/Interfaces/IWorldComponent.cs
+++ b/Core/Interfaces/IWorldComponent.cs
@@ -1,0 +1,19 @@
+using Verse;
+using RimWorld;
+
+namespace FreeWill.Core.Interfaces
+{
+    // Placeholder for RimWorld.Planet.WorldComponent
+    public interface IWorldComponent
+    {
+        FreeWill_ModSettings Settings { get; }
+
+        bool HasFreeWill(IPawn pawn, string pawnKey);
+        bool FreeWillCanChange(IPawn pawn, string pawnKey);
+        bool TryGiveFreeWill(IPawn pawn);
+        bool TryRemoveFreeWill(IPawn pawn);
+        void EnsureFreeWillStatusIsCorrect(IPawn pawn, string pawnKey);
+        void FreeWillOverride(IPawn pawn);
+        int FreeWillTicks(IPawn pawn);
+    }
+}


### PR DESCRIPTION
## Summary
- define placeholder interfaces for Pawn, Map, WorldComponent and WorkTypeDef
- include these new files in the Core project

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685144b535dc832384a57b51e666cd3e