### PR TITLE
docs: document workshop description

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ Use `-c Unstable` for a debug build.
 See [docs/architecture.md](docs/architecture.md) for an overview of how these pieces work together.
 
 For a detailed overview of features see [description.txt](description.txt).
+This file is also the description shown on the Steam Workshop. Update it for each
+release and follow the steps in [docs/workshop.md](docs/workshop.md) to keep the
+page in sync.

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -1,0 +1,11 @@
+# Steam Workshop Description
+
+`description.txt` contains the entire text shown on the mod's Steam Workshop page. It mirrors the README so players who install from Steam can see the full feature list and tips.
+
+When publishing a new release:
+
+1. Update `description.txt` with any changes or new features.
+2. Commit the updated file as part of the release pull request.
+3. After the release is published, copy the contents of `description.txt` into the Steam Workshop item description so the page matches the repository.
+
+Keeping the file in version control ensures the Workshop page stays in sync with each tagged release.


### PR DESCRIPTION
## Summary
- note that `description.txt` is used for the Steam Workshop page
- add release instructions for updating it

## Testing
- `apt-get update`
- `apt-get install -y mono-mcs`
- `dotnet build -c Stable` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514596b2d08323b391fc6ca7d49a41