### PR TITLE
refactor: move Priority to core and use interfaces

### DIFF
--- a/Core/FreeWill.Core.csproj
+++ b/Core/FreeWill.Core.csproj
@@ -9,8 +9,10 @@
   <ItemGroup>
     <Compile Include="Interfaces\IPawn.cs" />
     <Compile Include="Interfaces\IMap.cs" />
+    <Compile Include="Interfaces\IMapComponent.cs" />
     <Compile Include="Interfaces\IWorldComponent.cs" />
     <Compile Include="Interfaces\IWorkTypeDef.cs" />
+    <Compile Include="Priority.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Core/Interfaces/IMapComponent.cs
+++ b/Core/Interfaces/IMapComponent.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace FreeWill.Core.Interfaces
+{
+    // Placeholder for FreeWill_MapComponent
+    public interface IMapComponent
+    {
+        int NumPawns { get; }
+        float PercentPawnsNeedingTreatment { get; }
+        int NumPetsNeedingTreatment { get; }
+        int NumPrisonersNeedingTreatment { get; }
+        float PercentPawnsDowned { get; }
+        float PercentPawnsMechHaulers { get; }
+        float SuppressionNeed { get; }
+        Thing ThingsDeteriorating { get; }
+        int MapFires { get; }
+        bool HomeFire { get; }
+        bool RefuelNeededNow { get; }
+        bool RefuelNeeded { get; }
+        bool PlantsBlighted { get; }
+        bool AlertNeedWarmClothes { get; }
+        bool AlertColonistLeftUnburied { get; }
+        bool AlertAnimalRoaming { get; }
+        bool AlertLowFood { get; }
+        bool AlertMechDamaged { get; }
+        bool AlertAnimalPenNeeded { get; }
+        bool AlertAnimalPenNotEnclosed { get; }
+        bool AreaHasHaulables { get; }
+        bool AreaHasFilth { get; }
+        IEnumerable<Thought> AllThoughts { get; }
+        IEnumerable<IWorkTypeDef> DisabledWorkTypes { get; }
+        void UpdateLastBored(IPawn pawn);
+        int GetLastBored(IPawn pawn);
+    }
+}

--- a/Core/Priority.cs
+++ b/Core/Priority.cs
@@ -19,10 +19,10 @@ namespace FreeWill
         private const int DISABLED_CUTOFF_ACTIVE_WORK_AREA = 100 - DISABLED_CUTOFF; // 80 if LowestPriority is 4
         private const float ONE_PRIORITY_WIDTH = DISABLED_CUTOFF_ACTIVE_WORK_AREA / (float)Pawn_WorkSettings.LowestPriority; // ~20 if LowestPriority is 4
 
-        private readonly Pawn pawn;
-        private FreeWill_WorldComponent worldComp;
-        private FreeWill_MapComponent mapComp;
-        public WorkTypeDef WorkTypeDef { get; }
+        private readonly IPawn pawn;
+        private IWorldComponent worldComp;
+        private IMapComponent mapComp;
+        public IWorkTypeDef WorkTypeDef { get; }
         public float Value { get; private set; }
         public List<Func<string>> AdjustmentStrings { get; private set; }
 
@@ -61,7 +61,7 @@ namespace FreeWill
         /// </summary>
         /// <param name="pawn">Pawn to evaluate.</param>
         /// <param name="workTypeDef">Work type being processed.</param>
-        public Priority(Pawn pawn, WorkTypeDef workTypeDef)
+        public Priority(IPawn pawn, IWorkTypeDef workTypeDef)
         {
             this.pawn = pawn;
             WorkTypeDef = workTypeDef;
@@ -77,8 +77,8 @@ namespace FreeWill
             {
                 AdjustmentStrings = new List<Func<string>> { };
 
-                mapComp = pawn.Map.GetComponent<FreeWill_MapComponent>();
-                worldComp = Find.World.GetComponent<FreeWill_WorldComponent>();
+                mapComp = (IMapComponent)pawn.Map.GetComponent<FreeWill_MapComponent>();
+                worldComp = (IWorldComponent)Find.World.GetComponent<FreeWill_WorldComponent>();
 
                 // start priority at the global default and compute the priority
                 // using the AI in this file
@@ -890,7 +890,7 @@ namespace FreeWill
         {
             try
             {
-                mapComp = mapComp ?? pawn.Map.GetComponent<FreeWill_MapComponent>();
+                mapComp = mapComp ?? (IMapComponent)pawn.Map.GetComponent<FreeWill_MapComponent>();
                 foreach (Thought thought in mapComp.AllThoughts)
                 {
                     if (thought.def.defName == "NeedFood")
@@ -1726,7 +1726,7 @@ namespace FreeWill
                 }
                 Room room = pawn.GetRoom();
                 bool isPawnsRoom = false;
-                foreach (Pawn owner in room.Owners)
+                foreach (IPawn owner in room.Owners)
                 {
                     if (pawn == owner)
                     {
@@ -1775,7 +1775,7 @@ namespace FreeWill
         {
             try
             {
-                foreach (Pawn other in pawn.Map.mapPawns.PawnsInFaction(Faction.OfPlayer))
+                foreach (IPawn other in pawn.Map.mapPawns.PawnsInFaction(Faction.OfPlayer))
                 {
                     if (IsDoing(other))
                     {
@@ -1794,7 +1794,7 @@ namespace FreeWill
             }
         }
 
-        private bool IsDoing(Pawn other)
+        private bool IsDoing(IPawn other)
         {
             try
             {
@@ -1842,7 +1842,7 @@ namespace FreeWill
                     return this;
                 }
 
-                List<Pawn> allPawns = pawn.Map.mapPawns.PawnsInFaction(Faction.OfPlayer);
+                List<IPawn> allPawns = pawn.Map.mapPawns.PawnsInFaction(Faction.OfPlayer);
                 if (allPawns.Count() <= 1)
                 {
                     return this;
@@ -1850,7 +1850,7 @@ namespace FreeWill
                 bool isBestAtDoing = true;
                 float pawnSkill = pawn.skills.AverageOfRelevantSkillsFor(WorkTypeDef);
                 float impactPerPawn = worldComp.Settings.ConsiderBestAtDoing / allPawns.Count();
-                foreach (Pawn other in allPawns)
+                foreach (IPawn other in allPawns)
                 {
                     float otherSkill;
                     try
@@ -2380,7 +2380,7 @@ namespace FreeWill
             }
         }
 
-        private bool NotInHomeArea(Pawn pawn)
+        private bool NotInHomeArea(IPawn pawn)
         {
             try
             {

--- a/FreeWill.csproj
+++ b/FreeWill.csproj
@@ -26,7 +26,12 @@
     <Compile Include="ThoughtWorkers\EnforcedWorkSchedule.cs" />
     <Compile Include="ThoughtWorkers\NoWorkSchedule.cs" />
     <Compile Include="ThoughtWorkers\ThoughtWorker_Precept_FreeWillStreak.cs" />
-    <Compile Include="Priority.cs" />
+    <Compile Include="Core\Priority.cs" />
+    <Compile Include="Core\Interfaces\IPawn.cs" />
+    <Compile Include="Core\Interfaces\IMap.cs" />
+    <Compile Include="Core\Interfaces\IMapComponent.cs" />
+    <Compile Include="Core\Interfaces\IWorldComponent.cs" />
+    <Compile Include="Core\Interfaces\IWorkTypeDef.cs" />
     <Folder Include="About\" />
     <Folder Include="Assemblies\" />
     <Folder Include="Defs\" />

--- a/FreeWill_MapComponent.cs
+++ b/FreeWill_MapComponent.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using RimWorld;
 using Verse;
 using Verse.AI;
+using FreeWill.Core.Interfaces;
 
 namespace FreeWill
 {
@@ -12,7 +13,7 @@ namespace FreeWill
     /// MapComponent responsible for computing pawn work priorities and
     /// caching various map level state needed by the mod.
     /// </summary>
-    public class FreeWill_MapComponent : MapComponent
+    public class FreeWill_MapComponent : MapComponent, IMapComponent
     {
         private static readonly string[] mapComponentCheckActions = new string[]{
             "checkPrisonerHealth",
@@ -61,6 +62,9 @@ namespace FreeWill
         public bool AreaHasFilth { get; private set; }
         public List<Thought> AllThoughts = new List<Thought>();
         public List<WorkTypeDef> DisabledWorkTypes = new List<WorkTypeDef>();
+
+        IEnumerable<Thought> IMapComponent.AllThoughts => AllThoughts;
+        IEnumerable<IWorkTypeDef> IMapComponent.DisabledWorkTypes => DisabledWorkTypes.Cast<IWorkTypeDef>();
 
         private int actionCounter = 0;
 
@@ -190,6 +194,11 @@ namespace FreeWill
             lastBored[pawn] = Find.TickManager.TicksGame;
         }
 
+        void IMapComponent.UpdateLastBored(IPawn pawn)
+        {
+            UpdateLastBored((Pawn)pawn);
+        }
+
         /// <summary>
         /// Gets the tick count when the pawn was last bored.
         /// </summary>
@@ -198,6 +207,11 @@ namespace FreeWill
         public int GetLastBored(Pawn pawn)
         {
             return lastBored.ContainsKey(pawn) ? lastBored[pawn] : 0;
+        }
+
+        int IMapComponent.GetLastBored(IPawn pawn)
+        {
+            return GetLastBored((Pawn)pawn);
         }
 
         /// <summary>

--- a/FreeWill_WorldComponent.cs
+++ b/FreeWill_WorldComponent.cs
@@ -4,6 +4,7 @@ using HarmonyLib;
 using RimWorld;
 using RimWorld.Planet;
 using Verse;
+using FreeWill.Core.Interfaces;
 
 namespace FreeWill
 {
@@ -11,7 +12,7 @@ namespace FreeWill
     /// World component that tracks which pawns have free will and integrates
     /// ideology related behaviour.
     /// </summary>
-    public class FreeWill_WorldComponent : WorldComponent
+    public class FreeWill_WorldComponent : WorldComponent, IWorldComponent
     {
         private readonly FreeWill_Mod mod = LoadedModManager.GetMod<FreeWill_Mod>();
         public FreeWill_ModSettings Settings => mod.GetSettings<FreeWill_ModSettings>();
@@ -128,6 +129,11 @@ namespace FreeWill
             return freePawns[pawnKey];
         }
 
+        bool IWorldComponent.HasFreeWill(IPawn pawn, string pawnKey)
+        {
+            return HasFreeWill((Pawn)pawn, pawnKey);
+        }
+
         /// <summary>
         /// Checks whether the pawn's free will status can be changed by the player.
         /// </summary>
@@ -167,6 +173,11 @@ namespace FreeWill
                 Log.ErrorOnce("Free Will: could not check if free will can be changed", 48620057);
                 return false;
             }
+        }
+
+        bool IWorldComponent.FreeWillCanChange(IPawn pawn, string pawnKey)
+        {
+            return FreeWillCanChange((Pawn)pawn, pawnKey);
         }
 
         /// <summary>
@@ -211,6 +222,11 @@ namespace FreeWill
             }
         }
 
+        void IWorldComponent.EnsureFreeWillStatusIsCorrect(IPawn pawn, string pawnKey)
+        {
+            EnsureFreeWillStatusIsCorrect((Pawn)pawn, pawnKey);
+        }
+
         /// <summary>
         /// Attempts to grant free will to a pawn.
         /// </summary>
@@ -231,6 +247,11 @@ namespace FreeWill
             return true;
         }
 
+        bool IWorldComponent.TryGiveFreeWill(IPawn pawn)
+        {
+            return TryGiveFreeWill((Pawn)pawn);
+        }
+
         /// <summary>
         /// Attempts to remove free will from a pawn.
         /// </summary>
@@ -249,6 +270,11 @@ namespace FreeWill
             freePawns = freePawns ?? new Dictionary<string, bool> { };
             freePawns[pawn.GetUniqueLoadID()] = false;
             return true;
+        }
+
+        bool IWorldComponent.TryRemoveFreeWill(IPawn pawn)
+        {
+            return TryRemoveFreeWill((Pawn)pawn);
         }
 
         /// <summary>
@@ -274,6 +300,11 @@ namespace FreeWill
             {
                 Log.ErrorOnce("Free Will: error during FreeWillOverride", 1454146);
             }
+        }
+
+        void IWorldComponent.FreeWillOverride(IPawn pawn)
+        {
+            FreeWillOverride((Pawn)pawn);
         }
 
         /// <summary>
@@ -306,6 +337,11 @@ namespace FreeWill
                 Log.ErrorOnce("Free Will: error during FreeWillTicks: " + err.ToString(), 1454147);
                 return 0;
             }
+        }
+
+        int IWorldComponent.FreeWillTicks(IPawn pawn)
+        {
+            return FreeWillTicks((Pawn)pawn);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- migrate `Priority` into the Core project
- introduce `IMapComponent` and update components to implement the new interfaces
- compile core and main projects with interface definitions

## Testing
- `dotnet build` *(fails: .NET Framework reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851478bcadc8323a47ae039b75030d6